### PR TITLE
Bump build number. Build with rust 1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4ce5a708d65a8dbf3748d2474b580d606b1b9f91b5c6ab2a316e0b0cf7a4ba50
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6214](https://anaconda.atlassian.net/browse/PKG-6214)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6214]: https://anaconda.atlassian.net/browse/PKG-6214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ