### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.6" %}
+{% set version = "0.22.3" %}
 
 package:
   name: rpds-py
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/r/rpds-py/rpds_py-{{ version }}.tar.gz
-  sha256: 4ce5a708d65a8dbf3748d2474b580d606b1b9f91b5c6ab2a316e0b0cf7a4ba50
+  sha256: e32fee8ab45d3c2db6da19a5323bc3362237c8b653c70194414b892fd06a080d
 
 build:
-  number: 2
-  skip: true  # [py<38]
+  number: 0
+  skip: true  # [py<39]
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]
 
@@ -22,7 +22,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - maturin >=1.0,<2.0                     # [build_platform != target_platform]
   host:
-    - maturin >=1.0,<2.0
+    - maturin >=1.2,<2.0
     - pip
     - python
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4ce5a708d65a8dbf3748d2474b580d606b1b9f91b5c6ab2a316e0b0cf7a4ba50
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<38]
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'  # [s390x]


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.22.3
https://github.com/crate-py/rpds/tree/v0.22.3